### PR TITLE
feat(assert): Created simple assert handler for microcontroller to tr…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ else
 $(error "Must pass HW=LAUNCHPAD or HW=NSUMO")
 endif
 
-
 # Directories
 TOOLS_DIR = ${TOOLS_PATH}
 MSPGCC_ROOT_DIR = $(TOOLS_DIR)/msp430-gcc
@@ -26,7 +25,7 @@ DEBUG_DRIVERS_DIR = $(TI_CCS_DIR)/ccs_base/DebugServer/drivers
 
 LIB_DIRS= $(MSPGCC_INCLUDE_DIR)
 INCLUDE_DIRS = $(MSPGCC_INCLUDE_DIR) \
-	       ./src \
+		./src \
 	       ./external/ \
 	       ./external/printf
 
@@ -41,13 +40,15 @@ FORMAT = clang-format
 TARGET = $(BUILD_DIR)/$(TARGET_NAME)
 
 SOURCES_WITH_HEADERS = \
+	src/common/assert_handler.c \
 	src/drivers/mcu_init.c \
         src/drivers/uart.c \
+	src/drivers/led.c \
 	src/drivers/i2c.c \
 	src/drivers/io.c \
 	src/app/drive.c \
 	src/app/enemy.c \
-
+	
 SOURCES = \
 	src/main.c \
 	$(SOURCES_WITH_HEADERS)

--- a/src/common/assert_handler.c
+++ b/src/common/assert_handler.c
@@ -1,0 +1,30 @@
+#include "common/assert_handler.h"
+#include "common/defines.h"
+#include <msp430.h>
+#define BREAKPOINT __asm volatile("CLR.B R3");
+
+void assert_handler(void)
+{
+    // TODO: Turn off motors ("safe state")
+    // TODO: Trace to console
+    // TODO: Breakpoint
+    // TODO: Blink LED indefinitely
+    BREAKPOINT
+    // Configure TEST LED pin on LAUNCHPAD
+    P1SEL &= ~(BIT0);
+    P1SEL2 &= ~(BIT0);
+    P1DIR |= BIT0;
+    P1OUT &= ~(BIT0);
+
+    P2SEL &= ~(BIT6);
+    P2SEL2 &= ~(BIT6);
+    P2DIR |= BIT6;
+    P2OUT &= ~(BIT6);
+
+    while (1) {
+        // Blink LED on both target in case wrong target was flashed
+        P1OUT ^= BIT0;
+        P2OUT ^= BIT6;
+        BUSY_WAIT_ms(250);
+    };
+}

--- a/src/common/assert_handler.h
+++ b/src/common/assert_handler.h
@@ -1,0 +1,13 @@
+#ifndef ASSERT_HANDLER_H
+
+#include <stdint.h>
+
+#define ASSERT(expression)                                                                         \
+    do {                                                                                           \
+        if (!(expression)) {                                                                       \
+            assert_handler();                                                                      \
+        }                                                                                          \
+    } while (0)
+
+void assert_handler();
+#endif // ASSERT_HANDLER_H

--- a/src/common/defines.h
+++ b/src/common/defines.h
@@ -4,4 +4,9 @@
 #define UNUSED(x) (void)(x)
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
 
+// TODO: Change clock rate from 1 MHz to 16 MHz
+#define CYCLES_1MHZ (1000000u)
+#define ms_TO_CYCLES(ms) ((CYCLES_1MHZ / 1000u) * ms)
+#define BUSY_WAIT_ms(ms) (__delay_cycles(ms_TO_CYCLES(ms)))
+
 #endif // DEFINES_H

--- a/src/drivers/io.h
+++ b/src/drivers/io.h
@@ -1,6 +1,9 @@
 #ifndef IO_H
 #define IO_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
 /*
  IO pins handled for pinmapping, initialization, and configuration. This is an abstraction from the
  headers provided from TI that defines registers
@@ -89,8 +92,8 @@ typedef enum {
 } io_select_e;
 
 typedef enum {
-    IO_DIR_OUTPUT,
     IO_DIR_INPUT,
+    IO_DIR_OUTPUT,
 } io_dir_e;
 
 typedef enum {
@@ -117,6 +120,8 @@ struct io_config
 };
 
 void io_configure(io_e io, const struct io_config *config);
+void io_get_current_config(io_e io, struct io_config *current_config);
+bool io_config_compare(const struct io_config *cf1g, const struct io_config *cf2g);
 void io_set_select(io_e io, io_select_e select);
 void io_set_direction(io_e io, io_dir_e direction);
 void io_set_resistor(io_e io, io_resistor_e resistor);

--- a/src/drivers/led.c
+++ b/src/drivers/led.c
@@ -1,0 +1,33 @@
+#include "drivers/led.h"
+#include "drivers/io.h"
+#include "common/defines.h"
+#include "common/assert_handler.h"
+#include <stdbool.h>
+
+static const struct io_config led_config = {
+    .select = IO_SELECT_GPIO,
+    .resistor = IO_RESISTOR_DISABLED,
+    .dir = IO_DIR_OUTPUT,
+    .out = IO_OUT_LOW,
+};
+
+static bool initialized = false;
+void led_init(void)
+{
+    ASSERT(!initialized);
+    struct io_config current_config;
+    io_get_current_config(IO_TEST_LED, &current_config);
+    ASSERT(io_config_compare(&led_config, &current_config));
+    initialized = true;
+}
+
+void led_set(led_e led, led_state_e state)
+{
+    ASSERT(initialized);
+    const io_out_e out = (state == LED_STATE_ON) ? IO_OUT_HIGH : IO_OUT_LOW;
+    switch (led) {
+    case LED_TEST:
+        io_set_out(IO_TEST_LED, out);
+        break;
+    }
+}

--- a/src/drivers/led.h
+++ b/src/drivers/led.h
@@ -1,0 +1,17 @@
+#ifndef LED_H
+
+// Simple driver to test for LED
+
+typedef enum {
+    LED_TEST,
+} led_e;
+
+typedef enum {
+    LED_STATE_OFF,
+    LED_STATE_ON
+} led_state_e;
+
+void led_init(void);
+void led_set(led_e led, led_state_e state);
+
+#endif // LED_H

--- a/src/main.c
+++ b/src/main.c
@@ -1,22 +1,30 @@
-#include <drivers/io.h>
-#include <drivers/mcu_init.h>
+#include "drivers/io.h"
+#include "drivers/mcu_init.h"
+#include "drivers/led.h"
+#include "common/assert_handler.h"
+#include "common/defines.h"
 #include <msp430.h>
+
+/*
+
+static void test_assert(void)
+{
+        test_setup();
+        ASSERT(0);
+}
+*/
 
 static void test_setup(void) { mcu_init(); }
 
 static void test_blink_led(void)
 {
     test_setup();
-    const struct io_config led_config = { .dir = IO_DIR_OUTPUT,
-                                          .select = IO_SELECT_GPIO,
-                                          .resistor = IO_RESISTOR_DISABLED,
-                                          .out = IO_OUT_LOW };
-    io_configure(IO_TEST_LED, &led_config);
-    io_out_e out = IO_OUT_LOW;
+    led_init();
+    led_state_e led_state = LED_STATE_OFF;
     while (1) {
-        out = (out == IO_OUT_LOW) ? IO_OUT_HIGH : IO_OUT_LOW;
-        io_set_out(IO_TEST_LED, out);
-        __delay_cycles(250000); // 250ms
+        led_state = (led_state == LED_STATE_OFF) ? LED_STATE_ON : LED_STATE_OFF;
+        led_set(LED_TEST, led_state);
+        BUSY_WAIT_ms(1000); // 250ms
     }
 }
 
@@ -46,6 +54,7 @@ static void test_launchpad_io_pins_output(void)
 int main(void)
 {
     test_blink_led();
+    // test_assert();
     // test_launchpad_io_pins_output();
     return 0;
 }


### PR DESCRIPTION
…igger software breakpoint and blink

forever for the test LED. The handler evetually will be able to do console tracing and turning motors.

The LED driver was implemented to avoid interacting with direct IO functions, but careful using this with the assert handler because that can recursively be called and cause unexpected behavior.

__delay_cycles was replaced with macro BUSY_WAIT_ms to code readability to take milliseconds instead of cycles.