### PR TITLE
feat(assert): static assert size of io enum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ CPPCHECK_FLAGS = \
 # Flags
 MCU = msp430g2553
 WFLAGS = -Wall -Wextra -Werror -Wshadow
-CFLAGS = -mmcu=$(MCU) $(WFLAGS) $(addprefix -I,$(INCLUDE_DIRS)) $(DEFINES) -Og -g
+CFLAGS = -mmcu=$(MCU) $(WFLAGS) -fshort-enums $(addprefix -I,$(INCLUDE_DIRS)) $(DEFINES) -Og -g
 LDFLAGS = -mmcu=$(MCU) $(DEFINES) $(addprefix -L,$(LIB_DIRS))
 
 # Build

--- a/src/drivers/io.c
+++ b/src/drivers/io.c
@@ -3,6 +3,7 @@
 #include <msp430.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <assert.h>
 
 #define IO_PORT_OFFSET (3u)
 #define IO_PORT_MASK (0x3u << IO_PORT_OFFSET)
@@ -19,6 +20,7 @@
  * There are 3 ports and 8 pins.
  * [Zeros (11-bits) | Port (2 bits) | Pin (3 bits)] */
 
+static_assert(sizeof(io_generic_e) == 1, "Unexpected size, -fshort-enums missing?");
 static inline uint8_t io_port(io_e io) { return (io & IO_PORT_MASK) >> IO_PORT_OFFSET; }
 
 static inline uint8_t io_pin_idx(io_e io) { return (io & IO_PIN_MASK); }


### PR DESCRIPTION
Add static assertion with gcc compiler and microcontroller to verify that enums are only 1 byte long. Optimized for make to use -fshort-enums to save on flash memory.