### PR TITLE
feat(drivers): ADC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ SOURCES_WITH_HEADERS = \
 	src/drivers/tb6612fng.c \
 	src/drivers/i2c.c \
 	src/drivers/io.c \
+	src/drivers/adc.c \
 	src/app/drive.c \
 	src/app/enemy.c \
 	external/printf/printf.c \

--- a/src/drivers/adc.c
+++ b/src/drivers/adc.c
@@ -1,0 +1,97 @@
+#include "common/assert_handler.h"
+#include "common/defines.h"
+#include "drivers/adc.h"
+#include "drivers/io.h"
+#include <stdbool.h>
+#include <msp430.h>
+
+/* Setup ADC to sample sequence of channels including channels
+ * we are interested. Interrupt after sequence has been sampled
+ * and cache sampled values and start new round. Let caller retrieve
+ * latest values from cache. Use DMA (DTC) and slow clock (ACLK)
+ * to reduce CPU involvement.
+ * */
+static const io_e *adc_pins;
+static uint8_t adc_pin_cnt;
+static uint8_t dtc_channel_cnt;
+static volatile adc_channel_values_t adc_dtc_block;
+static volatile adc_channel_values_t adc_dtc_block_cache;
+
+static inline void adc_enable_and_start_conversion(void) { ADC10CTL0 |= ENC + ADC10SC; }
+
+static bool initialized = false;
+void adc_init(void)
+{
+    ASSERT(!initialized);
+    adc_pins = io_adc_pins(&adc_pin_cnt);
+
+    uint8_t adc10ae0 = 0;
+    uint8_t last_idx = 0;
+
+    for (uint8_t i = 0; i < adc_pin_cnt; i++) {
+        const uint8_t pin_idx = io_to_adc_idx(adc_pins[i]);
+        const uint8_t pin_bit = 1 << pin_idx;
+        adc10ae0 += pin_bit;
+        if (pin_idx > last_idx) {
+            last_idx = pin_idx;
+        }
+    }
+    const uint16_t inch = last_idx << 12;
+
+    // TODO: Compute inch
+    // TODO: Compute adc10ae0
+    // TODO: last_idx
+
+    /* ADC10DIV_7: Clock division (higher means slower)
+     * CONSEQ_1: Sequence of channels
+     * SHS_0: ADC10SC bit starts conversion
+     * ADC10SSEL_1: ACLK as clock source (slow)
+     * */
+
+    ADC10CTL1 = inch + ADC10DIV_7 + CONSEQ_1 + SHS_0 + ADC10SSEL_1;
+
+    /* ADC10ON: Enable
+     * SREF_0: Voltage reference (VCC and VSS)
+     * ADC10SHT_3: 64 * ADC10CLK sample and hold time (better readings?)
+     * MSC: Multiple sample conversion
+     * ADC10IE: Enable interrupt
+     * */
+
+    ADC10CTL0 = ADC10ON + SREF_0 + ADC10SHT_3 + MSC + ADC10IE;
+
+    ADC10AE0 = adc10ae0;
+
+    /* Use data transfer controler (DTC) to transfer data DMA-style
+     * from sample channels and interrupt afterwards. NOte, CONSEQ_1
+     * iterates channels contiguously from last idx to 0.
+     * */
+
+    dtc_channel_cnt = last_idx + 1;
+    ADC10DTC0 = ADC10CT;
+    ADC10DTC1 = dtc_channel_cnt;
+    ADC10SA = (uint16_t)adc_dtc_block;
+
+    adc_enable_and_start_conversion();
+
+    initialized = true;
+}
+
+INTERRUPT_FUNCTION(ADC10_VECTOR) isr_adc10(void)
+{
+    for (uint8_t i = 0; i < dtc_channel_cnt; i++) {
+        // DTC writes channel samples in reverse order
+        adc_dtc_block_cache[i] = adc_dtc_block[dtc_channel_cnt - 1 - i];
+    }
+    adc_enable_and_start_conversion();
+}
+
+void adc_get_channel_values(adc_channel_values_t values)
+{
+    // seems like disabling interrupts globally only works, not just adc interrupt
+    _disable_interrupts();
+    for (uint8_t i = 0; i < adc_pin_cnt; i++) {
+        const uint8_t channel_idx = io_to_adc_idx(adc_pins[i]);
+        values[channel_idx] = adc_dtc_block_cache[channel_idx];
+    }
+    _enable_interrupts();
+}

--- a/src/drivers/adc.h
+++ b/src/drivers/adc.h
@@ -1,0 +1,13 @@
+#ifndef ADC_H
+#define ADC_H
+
+#include <stdint.h>
+
+#define ADC_CHANNEL_COUNT (8u)
+
+typedef uint16_t adc_channel_values_t[ADC_CHANNEL_COUNT];
+
+void adc_init(void);
+void adc_get_channel_values(adc_channel_values_t values);
+
+#endif // ADC_H

--- a/src/drivers/io.c
+++ b/src/drivers/io.c
@@ -80,6 +80,12 @@ static isr_function isr_functions[IO_INTERRUPT_PORT_CNT][IO_PIN_CNT_PER_PORT] = 
         IO_SELECT_GPIO, IO_RESISTOR_ENABLED, IO_DIR_OUTPUT, IO_OUT_LOW                             \
     }
 
+// Overriden by ADC, so just default it to floating input here
+#define ADC_CONFIG                                                                                 \
+    {                                                                                              \
+        IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_INPUT, IO_OUT_LOW                             \
+    }
+
 static const struct io_config io_initial_configs[IO_PORT_CNT * IO_PIN_CNT_PER_PORT] = {
     [IO_TEST_LED] = { IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW },
     /* UART RX/TX
@@ -100,9 +106,10 @@ static const struct io_config io_initial_configs[IO_PORT_CNT * IO_PIN_CNT_PER_PO
     [IO_MOTORS_LEFT_CC_1] = { IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW },
     [IO_MOTORS_LEFT_CC_2] = { IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW },
 
+    [IO_LINE_DETECT_FRONT_LEFT] = ADC_CONFIG,
+
 #if defined(LAUNCHPAD)
     // unused pins
-    [IO_UNUSED_1] = UNUSED_CONFIG,
     [IO_UNUSED_2] = UNUSED_CONFIG,
     [IO_UNUSED_3] = UNUSED_CONFIG,
     [IO_UNUSED_5] = UNUSED_CONFIG,
@@ -142,15 +149,16 @@ static const struct io_config io_initial_configs[IO_PORT_CNT * IO_PIN_CNT_PER_PO
     [IO_XSHUT_LEFT] = { IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW },
     [IO_XSHUT_FRONT_RIGHT] = { IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT, IO_OUT_LOW },
 
-    // Overriden by ADC, so just default it to floating input here
-    [IO_LINE_DETECT_FRONT_RIGHT] = { IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT,
-                                     IO_OUT_LOW },
-    [IO_LINE_DETECT_FRONT_LEFT] = { IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT,
-                                    IO_OUT_LOW },
-    [IO_LINE_DETECT_BACK_RIGHT] = { IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT,
-                                    IO_OUT_LOW },
-    [IO_LINE_DETECT_BACK_LEFT] = { IO_SELECT_GPIO, IO_RESISTOR_DISABLED, IO_DIR_OUTPUT,
-                                   IO_OUT_LOW },
+    [IO_LINE_DETECT_FRONT_RIGHT] = ADC_CONFIG,
+    [IO_LINE_DETECT_BACK_RIGHT] = ADC_CONFIG,
+    [IO_LINE_DETECT_BACK_LEFT] = ADC_CONFIG,
+#endif
+};
+
+static const io_e io_adc_pins_arr[] = { IO_LINE_DETECT_FRONT_LEFT,
+#if defined(NSUMO)
+                                        IO_LINE_DETECT_BACK_LEFT, IO_LINE_DETECT_FRONT_RIGHT,
+                                        IO_LINE_DETECT_BACK_RIGHT
 #endif
 };
 
@@ -289,6 +297,19 @@ io_in_e io_get_input(io_e io)
 static void io_clear_interrupt(io_e io)
 {
     *port_interrupt_flag_regs[io_port(io)] &= ~io_pin_bit(io);
+}
+
+const io_e *io_adc_pins(uint8_t *cnt)
+{
+    *cnt = ARRAY_SIZE(io_adc_pins_arr);
+    return io_adc_pins_arr;
+}
+
+uint8_t io_to_adc_idx(io_e io)
+{
+    // only pins on port 1 supports ADC
+    ASSERT(io_port(io) == IO_PORT1);
+    return io_pin_idx(io);
 }
 
 /* Function also disables interrupt because selecting edge may trigger

--- a/src/drivers/io.h
+++ b/src/drivers/io.h
@@ -43,7 +43,7 @@ typedef enum {
     IO_TEST_LED = IO_10,
     IO_UART_RXD = IO_11,
     IO_UART_TXD = IO_12,
-    IO_UNUSED_1 = IO_13,
+    IO_LINE_DETECT_FRONT_LEFT = IO_13,
     IO_UNUSED_2 = IO_14,
     IO_UNUSED_3 = IO_15,
     IO_PWM_MOTORS_LEFT = IO_16,
@@ -132,6 +132,9 @@ void io_set_direction(io_e io, io_dir_e direction);
 void io_set_resistor(io_e io, io_resistor_e resistor);
 void io_set_out(io_e io, io_out_e out);
 io_in_e io_get_input(io_e io);
+const io_e *io_adc_pins(uint8_t *cnt);
+uint8_t io_to_adc_idx(io_e io);
+
 void io_init(void);
 
 typedef void (*isr_function)(void);

--- a/src/drivers/mcu_init.c
+++ b/src/drivers/mcu_init.c
@@ -27,6 +27,9 @@ static void init_clocks()
      * SMCLK: Sub system clock drives some peripherals
      * */
     // BCSCTL2 default
+
+    // Select internal Very Low Frequency Oscillator (VLO) as ACLK source
+    BCSCTL3 = LFXT1S_2;
 }
 
 static void watchdog_stop(void) { WDTCTL = WDTPW + WDTHOLD; }

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -6,6 +6,7 @@
 #include "drivers/ir_remote.h"
 #include "drivers/pwm.h"
 #include "drivers/tb6612fng.h"
+#include "drivers/adc.h"
 #include "common/assert_handler.h"
 #include "common/defines.h"
 #include "common/trace.h"
@@ -296,6 +297,26 @@ static void test_assert_motors(void)
     ASSERT(0);
     while(0) { }
 }
+
+SUPRESS_UNUSED
+static void test_adc(void)
+{
+   test_setup();
+   trace_init();
+   adc_init();
+
+   while (1)
+   {
+	adc_channel_values_t values;
+	adc_get_channel_values(values);
+
+	for (uint8_t i = 0; i < ADC_CHANNEL_COUNT; i++) {
+		TRACE("ADC ch %u: %u", i, values[i]);
+	}
+	BUSY_WAIT_ms(1000);
+   }
+}
+
 int main()
 {
 	TEST();


### PR DESCRIPTION
Create ADC driver to sample voltages from the sensors. Since robot has 4 line sensors that gives voltage output based on light intensity in front of them, which akes it possible to detect white boundary of sumobot platform. Interrupt each time channels have been sampled, cache them, and start next round. Reduce CPU workload bu using DMA and a slow clock (ACLK).