### PR TITLE
fix(build): rebuild files when changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: samloveswater/msp430-gcc-9.3.1.11:latest
+    env:
+      TOOLS_PATH: /home/ubuntu/dev/tools
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -14,9 +16,9 @@ jobs:
       - run: git config diff.ignoreSubmodules all
       - run: make format
       - run: make cppcheck
-      - run: TOOLS_PATH=/home/ubuntu/dev/tools make HW=LAUNCHPAD size
-      - run: TOOLS_PATH=/home/ubuntu/dev/tools make HW=LAUNCHPAD symbols
-      - run: TOOLS_PATH=/home/ubuntu/dev/tools make HW=NSUMO
-      - run: TOOLS_PATH=/home/ubuntu/dev/tools make HW=LAUNCHPAD
-      - run: TOOLS_PATH=/home/ubuntu/dev/tools tools/build_tests.sh
+      - run: make HW=LAUNCHPAD size
+      - run: make HW=LAUNCHPAD symbols
+      - run: make HW=NSUMO
+      - run: make HW=LAUNCHPAD
+      - run: make tests
 

--- a/src/common/assert_handler.c
+++ b/src/common/assert_handler.c
@@ -21,8 +21,8 @@
 static void assert_trace(uint16_t program_counter)
 {
     // UART Tx
-    P1SEL |= BIT1;
-    P1SEL2 |= BIT1;
+    P1SEL |= BIT2;
+    P1SEL2 |= BIT2;
     uart_init();
     char assert_string[ASSERT_STRING_MAX_SIZE];
     snprintf(assert_string, sizeof(assert_string), "ASSERT 0x%x\n", program_counter);


### PR DESCRIPTION
Fixed makefile issue where we don't have to rebuild by removing test.o and force rebuilding it all the time.

Added 2 new rules for starting serial terminal (UART) and building all the test cases for make.